### PR TITLE
fix: support multi-contract accounts

### DIFF
--- a/custom_components/eyeonsaur/__init__.py
+++ b/custom_components/eyeonsaur/__init__.py
@@ -29,11 +29,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    # Set up platforms
+    # Set up platforms (creates sensor entities)
     await hass.config_entries.async_forward_entry_setups(
         entry,
         PLATFORMS,
     )
+
+    # Inject historical data AFTER entities exist
+    await coordinator.async_inject_all_historical_data()
 
     # Add listener for config and options updates
     entry.async_on_unload(

--- a/custom_components/eyeonsaur/coordinator.py
+++ b/custom_components/eyeonsaur/coordinator.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.update_coordinator import (
 from homeassistant.util.dt import as_local
 from homeassistant.util.dt import now as hass_now
 from saur_client import (
+    SaurApiError,
     SaurClient,
     SaurResponseContracts,
     SaurResponseDelivery,
@@ -323,7 +324,7 @@ class SaurCoordinator(DataUpdateCoordinator[SaurData]):
             monthly_data: SaurResponseMonthly = (
                 await self.client.get_monthly_data(year, month, section_id)
             )
-        except ClientResponseError:
+        except (ClientResponseError, SaurApiError):
             # Ajoute à la blacklist en cas d'erreur
             self.blacklisted_months.add((year, month))
             _LOGGER.warning(

--- a/custom_components/eyeonsaur/coordinator.py
+++ b/custom_components/eyeonsaur/coordinator.py
@@ -171,8 +171,8 @@ class SaurCoordinator(DataUpdateCoordinator[SaurData]):
 
             # Créer un device pour le compteur
             device_info = DeviceInfo(
-                identifiers={(DOMAIN, compteur.clientReference)},
-                name=f"Contrat {compteur.clientReference}",
+                identifiers={(DOMAIN, compteur.contractId)},
+                name=f"Contrat {compteur.contractName} ({compteur.contractId})",
                 manufacturer="EyeOnSaur",
                 model="Contrat",
                 entry_type=DeviceEntryType.SERVICE,

--- a/custom_components/eyeonsaur/coordinator.py
+++ b/custom_components/eyeonsaur/coordinator.py
@@ -529,23 +529,13 @@ class SaurCoordinator(DataUpdateCoordinator[SaurData]):
             *last_tasks, return_exceptions=True
         )
 
-        filtered_delivery_results = [
-            d for d in delivery_results if isinstance(d, dict)
-        ]
-        filtered_last_results = [
-            d for d in last_results if isinstance(d, dict)
-        ]
-
         # 3. Mettre à jour les compteurs avec les données DELIVERY et LAST
         updated_compteurs: list[Compteur] = []
-        for i, (delivery_data, last_data) in enumerate(
-            zip(filtered_delivery_results, filtered_last_results, strict=False)
-            # zip(delivery_results, last_results, strict=False)
-        ):
-            compteur = compteurs[i]
+        for i, compteur in enumerate(compteurs):
+            delivery_data = delivery_results[i]
+            last_data = last_results[i]
 
-            if isinstance(delivery_data, HomeAssistantError):
-                # Gestion de l'erreur DELIVERY : on log mais on continue
+            if isinstance(delivery_data, Exception):
                 _LOGGER.error(
                     "Erreur lors de la mise à jour du compteur %s avec les "
                     "données DELIVERY: %s. Utilisation des anciennes données.",
@@ -553,11 +543,9 @@ class SaurCoordinator(DataUpdateCoordinator[SaurData]):
                     delivery_data,
                 )
             else:
-                # on utilise la methode update_delivery de la class Compteur
                 compteur.update_delivery(delivery_data)
 
-            if isinstance(last_data, HomeAssistantError):
-                # Gestion de l'erreur LAST : on log l'erreur mais on continue
+            if isinstance(last_data, Exception):
                 _LOGGER.error(
                     "Erreur lors de la mise à jour du compteur %s avec les "
                     "données LAST: %s. Utilisation des anciennes données.",
@@ -565,7 +553,6 @@ class SaurCoordinator(DataUpdateCoordinator[SaurData]):
                     last_data,
                 )
             else:
-                # on utilise la methode update_last de la class Compteur
                 compteur.update_last(last_data)
 
             updated_compteurs.append(compteur)

--- a/custom_components/eyeonsaur/sensor.py
+++ b/custom_components/eyeonsaur/sensor.py
@@ -52,7 +52,7 @@ async def async_setup_entry(
             name=f"Compteur {compteur.serial_number}",
             manufacturer=compteur.manufacturer,
             model=compteur.model,
-            via_device=(DOMAIN, compteur.clientReference),
+            via_device=(DOMAIN, compteur.contractId),
             serial_number=compteur.serial_number,
             sw_version=compteur.sectionId,
         )

--- a/custom_components/eyeonsaur/sensor.py
+++ b/custom_components/eyeonsaur/sensor.py
@@ -188,7 +188,7 @@ class SaurStatisticsSensor(SensorEntity):
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_suggested_display_precision = 2
     _attr_should_poll = False
-    _attr_disabled_by_default = True
+    _attr_disabled_by_default = False
     _attr_native_value = None  # Jamais de valeur
 
     def __init__(


### PR DESCRIPTION
Fixes https://github.com/cekage/eyeonsaur-ha/issues/7

## Summary

- **Device identity collision**: accounts with multiple `customerAccounts` under the same `clientId` shared the same `clientReference`, causing HA to merge them into a single device. Now uses `contractId` (unique per customerAccount) as device identifier.
- **Compteurs silently dropped**: `update_compteurs_with_delivery_points` filtered out API errors before zipping with the compteurs list, causing the second compteur to be silently dropped when any API call failed. Now iterates directly over compteurs and handles errors inline.
- **Uncaught SaurApiError on monthly fetch**: `saur_client` wraps `ClientResponseError` into `SaurApiError`, but the except clause only caught `ClientResponseError`. A 404 on the monthly endpoint crashed the entire setup instead of blacklisting the month.

## Test plan

- [ ] Account with a single contract still works as before
- [ ] Account with multiple `customerAccounts` under the same `clientId` now shows one device per contract
- [ ] A 404 on the monthly consumption endpoint no longer crashes setup